### PR TITLE
Improve default TLS settings to A grade (#3)

### DIFF
--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -58,7 +58,7 @@ RUN apt-get update \
  # Install tools for building
 <? if ($isAlpineImage) { ?>
  && apk add --no-cache --virtual .tool-deps \
-        curl coreutils autoconf g++ libtool make \
+        curl coreutils autoconf g++ libtool make libressl \
 <? } else { ?>
  && toolDeps=" \
         curl make gcc g++ libc-dev \
@@ -197,8 +197,44 @@ RUN apt-get update \
            -e 's,^html_directory =.*,html_directory = no,' \
         /etc/postfix/main.cf \
  # Prepare directories for drop-in configuration files
- && mkdir -p /etc/postfix/main.cf.d \
- && mkdir -p /etc/postfix/master.cf.d \
+ && install -d /etc/postfix/main.cf.d \
+ && install -d /etc/postfix/master.cf.d \
+ # Generate default TLS credentials
+ && install -d /etc/ssl/postfix \
+ && openssl req -new -x509 -nodes -days 365 \
+                -subj "/CN=smtp.example.com" \
+                -out /etc/ssl/postfix/server.crt \
+                -keyout /etc/ssl/postfix/server.key \
+ && chmod 0600 /etc/ssl/postfix/server.key \
+ # Pregenerate Diffie-Hellman parameters (heavy operation)
+ && openssl dhparam -out /etc/postfix/dh2048.pem 2048 \
+ # Tweak TLS/SSL settings to achieve A grade
+<? if ($isAlpineImage) { ?>
+ && echo -e "\n\
+<? } else { ?>
+ && echo "\n\
+<? } ?>
+    \n# TLS PARAMETERS\
+    \n#\
+    \ntls_ssl_options = NO_COMPRESSION\
+    \ntls_high_cipherlist = ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256\
+    \n\n\
+    \n# SMTP TLS PARAMETERS (outgoing connections)\
+    \n#\
+    \nsmtp_tls_security_level = may\
+    \nsmtp_tls_CApath = /etc/ssl/certs\
+    \n\n\
+    \n# SMTPD TLS PARAMETERS (incoming connections)\
+    \n#\
+    \nsmtpd_tls_security_level = may\
+    \nsmtpd_tls_ciphers = high\
+    \nsmtpd_tls_mandatory_ciphers = high\
+    \nsmtpd_tls_exclude_ciphers = aNULL, LOW, EXP, MEDIUM, ADH, AECDH, MD5, DSS, ECDSA, CAMELLIA128, 3DES, CAMELLIA256, RSA+AES, eNULL\
+    \nsmtpd_tls_dh1024_param_file = /etc/postfix/dh2048.pem\
+    \nsmtpd_tls_CApath = /etc/ssl/certs\
+    \nsmtpd_tls_cert_file = /etc/ssl/postfix/server.crt\
+    \nsmtpd_tls_key_file = /etc/ssl/postfix/server.key\
+    " >> /etc/postfix/main.cf \
 
  # Cleanup unnecessary stuff
 <? if ($isAlpineImage) { ?>

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -24,7 +24,7 @@ RUN apk update \
 
  # Install tools for building
  && apk add --no-cache --virtual .tool-deps \
-        curl coreutils autoconf g++ libtool make \
+        curl coreutils autoconf g++ libtool make libressl \
 
  # Install Postfix build dependencies
  && apk add --no-cache --virtual .build-deps \
@@ -110,8 +110,40 @@ RUN apk update \
            -e 's,^html_directory =.*,html_directory = no,' \
         /etc/postfix/main.cf \
  # Prepare directories for drop-in configuration files
- && mkdir -p /etc/postfix/main.cf.d \
- && mkdir -p /etc/postfix/master.cf.d \
+ && install -d /etc/postfix/main.cf.d \
+ && install -d /etc/postfix/master.cf.d \
+ # Generate default TLS credentials
+ && install -d /etc/ssl/postfix \
+ && openssl req -new -x509 -nodes -days 365 \
+                -subj "/CN=smtp.example.com" \
+                -out /etc/ssl/postfix/server.crt \
+                -keyout /etc/ssl/postfix/server.key \
+ && chmod 0600 /etc/ssl/postfix/server.key \
+ # Pregenerate Diffie-Hellman parameters (heavy operation)
+ && openssl dhparam -out /etc/postfix/dh2048.pem 2048 \
+ # Tweak TLS/SSL settings to achieve A grade
+ && echo -e "\n\
+    \n# TLS PARAMETERS\
+    \n#\
+    \ntls_ssl_options = NO_COMPRESSION\
+    \ntls_high_cipherlist = ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256\
+    \n\n\
+    \n# SMTP TLS PARAMETERS (outgoing connections)\
+    \n#\
+    \nsmtp_tls_security_level = may\
+    \nsmtp_tls_CApath = /etc/ssl/certs\
+    \n\n\
+    \n# SMTPD TLS PARAMETERS (incoming connections)\
+    \n#\
+    \nsmtpd_tls_security_level = may\
+    \nsmtpd_tls_ciphers = high\
+    \nsmtpd_tls_mandatory_ciphers = high\
+    \nsmtpd_tls_exclude_ciphers = aNULL, LOW, EXP, MEDIUM, ADH, AECDH, MD5, DSS, ECDSA, CAMELLIA128, 3DES, CAMELLIA256, RSA+AES, eNULL\
+    \nsmtpd_tls_dh1024_param_file = /etc/postfix/dh2048.pem\
+    \nsmtpd_tls_CApath = /etc/ssl/certs\
+    \nsmtpd_tls_cert_file = /etc/ssl/postfix/server.crt\
+    \nsmtpd_tls_key_file = /etc/ssl/postfix/server.key\
+    " >> /etc/postfix/main.cf \
 
  # Cleanup unnecessary stuff
  && apk del .tool-deps .build-deps \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -104,8 +104,40 @@ RUN apt-get update \
            -e 's,^html_directory =.*,html_directory = no,' \
         /etc/postfix/main.cf \
  # Prepare directories for drop-in configuration files
- && mkdir -p /etc/postfix/main.cf.d \
- && mkdir -p /etc/postfix/master.cf.d \
+ && install -d /etc/postfix/main.cf.d \
+ && install -d /etc/postfix/master.cf.d \
+ # Generate default TLS credentials
+ && install -d /etc/ssl/postfix \
+ && openssl req -new -x509 -nodes -days 365 \
+                -subj "/CN=smtp.example.com" \
+                -out /etc/ssl/postfix/server.crt \
+                -keyout /etc/ssl/postfix/server.key \
+ && chmod 0600 /etc/ssl/postfix/server.key \
+ # Pregenerate Diffie-Hellman parameters (heavy operation)
+ && openssl dhparam -out /etc/postfix/dh2048.pem 2048 \
+ # Tweak TLS/SSL settings to achieve A grade
+ && echo "\n\
+    \n# TLS PARAMETERS\
+    \n#\
+    \ntls_ssl_options = NO_COMPRESSION\
+    \ntls_high_cipherlist = ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256\
+    \n\n\
+    \n# SMTP TLS PARAMETERS (outgoing connections)\
+    \n#\
+    \nsmtp_tls_security_level = may\
+    \nsmtp_tls_CApath = /etc/ssl/certs\
+    \n\n\
+    \n# SMTPD TLS PARAMETERS (incoming connections)\
+    \n#\
+    \nsmtpd_tls_security_level = may\
+    \nsmtpd_tls_ciphers = high\
+    \nsmtpd_tls_mandatory_ciphers = high\
+    \nsmtpd_tls_exclude_ciphers = aNULL, LOW, EXP, MEDIUM, ADH, AECDH, MD5, DSS, ECDSA, CAMELLIA128, 3DES, CAMELLIA256, RSA+AES, eNULL\
+    \nsmtpd_tls_dh1024_param_file = /etc/postfix/dh2048.pem\
+    \nsmtpd_tls_CApath = /etc/ssl/certs\
+    \nsmtpd_tls_cert_file = /etc/ssl/postfix/server.crt\
+    \nsmtpd_tls_key_file = /etc/ssl/postfix/server.key\
+    " >> /etc/postfix/main.cf \
 
  # Cleanup unnecessary stuff
  && apt-get purge -y --auto-remove \


### PR DESCRIPTION
Resolves #3

This PR improves default TLS settings of Postfix inside Docker image to receive A grade with Nmap.