### PR TITLE
Revert chroot using

### DIFF
--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -29,7 +29,6 @@ MAINTAINER Instrumentisto Team <developer@instrumentisto.com>
 RUN apk update \
  && apk upgrade \
  && apk add --no-cache \
-        inetutils-syslogd \
         ca-certificates \
 <? } else { ?>
 # https://git.launchpad.net/postfix/tree/debian/rules?id=<?= $DebianRepoCommit."\n"; ?>
@@ -200,11 +199,6 @@ RUN apt-get update \
  # Prepare directories for drop-in configuration files
  && install -d /etc/postfix/main.cf.d \
  && install -d /etc/postfix/master.cf.d \
- # Prepare syslog socket directory for chrooted processes
- && install -d /var/spool/postfix/dev \
- # Chroot Postfix services by default
- && sed -i -E 's/^(#?(smtp[ds]?|dnsblog|tlsproxy|submission|628|pickup|cleanup|qmgr|tlsmgr|rewrite|bounce|defer|trace|verify|flush|relay|showq|error|retry|discard|lmtp|anvil|scache)[ ]+(inet|unix|pass)[ ]+[ny-][ ]+[ny-][ ]+)[n-]/\1y/' \
-        /etc/postfix/master.cf \
  # Generate default TLS credentials
  && install -d /etc/ssl/postfix \
  && openssl req -new -x509 -nodes -days 365 \
@@ -246,14 +240,13 @@ RUN apt-get update \
 <? if ($isAlpineImage) { ?>
  && apk del .tool-deps .build-deps \
  && rm -rf /var/cache/apk/* \
-           /sbin/setup-inetutils-syslogd \
 <? } else { ?>
  && apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \
             $toolDeps $buildDeps \
  && rm -rf /var/lib/apt/lists/* \
-<? } ?>
            /etc/*/inetutils-syslogd \
+<? } ?>
            /tmp/*
 
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,7 +12,6 @@ MAINTAINER Instrumentisto Team <developer@instrumentisto.com>
 RUN apk update \
  && apk upgrade \
  && apk add --no-cache \
-        inetutils-syslogd \
         ca-certificates \
  && update-ca-certificates \
 
@@ -113,11 +112,6 @@ RUN apk update \
  # Prepare directories for drop-in configuration files
  && install -d /etc/postfix/main.cf.d \
  && install -d /etc/postfix/master.cf.d \
- # Prepare syslog socket directory for chrooted processes
- && install -d /var/spool/postfix/dev \
- # Chroot Postfix services by default
- && sed -i -E 's/^(#?(smtp[ds]?|dnsblog|tlsproxy|submission|628|pickup|cleanup|qmgr|tlsmgr|rewrite|bounce|defer|trace|verify|flush|relay|showq|error|retry|discard|lmtp|anvil|scache)[ ]+(inet|unix|pass)[ ]+[ny-][ ]+[ny-][ ]+)[n-]/\1y/' \
-        /etc/postfix/master.cf \
  # Generate default TLS credentials
  && install -d /etc/ssl/postfix \
  && openssl req -new -x509 -nodes -days 365 \
@@ -154,8 +148,6 @@ RUN apk update \
  # Cleanup unnecessary stuff
  && apk del .tool-deps .build-deps \
  && rm -rf /var/cache/apk/* \
-           /sbin/setup-inetutils-syslogd \
-           /etc/*/inetutils-syslogd \
            /tmp/*
 
 

--- a/alpine/rootfs/etc/services.d/syslog/run
+++ b/alpine/rootfs/etc/services.d/syslog/run
@@ -1,8 +1,3 @@
 #!/bin/sh
 
-# Make sure that socket directory exists
-# in case /var/spool/postfix/ is a mounted volume.
-mkdir -p /var/spool/postfix/dev/
-
-# Start syslogd daemon with additional listener in Postfix chroot dir.
-exec syslogd -n -a /var/spool/postfix/dev/log
+exec syslogd -n

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -106,11 +106,6 @@ RUN apt-get update \
  # Prepare directories for drop-in configuration files
  && install -d /etc/postfix/main.cf.d \
  && install -d /etc/postfix/master.cf.d \
- # Prepare syslog socket directory for chrooted processes
- && install -d /var/spool/postfix/dev \
- # Chroot Postfix services by default
- && sed -i -E 's/^(#?(smtp[ds]?|dnsblog|tlsproxy|submission|628|pickup|cleanup|qmgr|tlsmgr|rewrite|bounce|defer|trace|verify|flush|relay|showq|error|retry|discard|lmtp|anvil|scache)[ ]+(inet|unix|pass)[ ]+[ny-][ ]+[ny-][ ]+)[n-]/\1y/' \
-        /etc/postfix/master.cf \
  # Generate default TLS credentials
  && install -d /etc/ssl/postfix \
  && openssl req -new -x509 -nodes -days 365 \

--- a/debian/rootfs/etc/services.d/syslog/run
+++ b/debian/rootfs/etc/services.d/syslog/run
@@ -1,8 +1,3 @@
 #!/bin/sh
 
-# Make sure that socket directory exists
-# in case /var/spool/postfix/ is a mounted volume.
-mkdir -p /var/spool/postfix/dev/
-
-# Start syslogd daemon with additional listener in Postfix chroot dir.
-exec syslogd -n -a /var/spool/postfix/dev/log
+exec syslogd -n

--- a/rootfs/etc/services.d/syslog/run
+++ b/rootfs/etc/services.d/syslog/run
@@ -1,8 +1,3 @@
 #!/bin/sh
 
-# Make sure that socket directory exists
-# in case /var/spool/postfix/ is a mounted volume.
-mkdir -p /var/spool/postfix/dev/
-
-# Start syslogd daemon with additional listener in Postfix chroot dir.
-exec syslogd -n -a /var/spool/postfix/dev/log
+exec syslogd -n

--- a/test/resources/master.cf.d/01-simple.cf
+++ b/test/resources/master.cf.d/01-simple.cf
@@ -1,1 +1,1 @@
-verify    unix  -       -       n       -       1       verify
+verify    unix  -       -       y       -       1       verify

--- a/test/resources/master.cf.d/10-pickup-unix-to-fifo.postconf
+++ b/test/resources/master.cf.d/10-pickup-unix-to-fifo.postconf
@@ -1,7 +1,7 @@
 # Disable pickup/unix service
--M pickup/unix=#pickup    unix  n       -       y       60      1       pickup
+-M pickup/unix=#pickup    unix  n       -       n       60      1       pickup
 
 # Enable pickup/fifo service instead and configure it
--M pickup/fifo=pickup    fifo  n       -       y       60      1       pickup
+-M pickup/fifo=pickup    fifo  n       -       n       60      1       pickup
 -P pickup/fifo/content_filter=
 -P pickup/fifo/receive_override_options=no_header_body_checks

--- a/test/resources/master.cf.d/20-chroot-lmtp.postconf
+++ b/test/resources/master.cf.d/20-chroot-lmtp.postconf
@@ -1,2 +1,2 @@
 # Unchroot lmtp/unix service
--F lmtp/unix/chroot=n
+-F lmtp/unix/chroot=y

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -62,7 +62,7 @@
   run docker run --rm \
     -v $(pwd)/test/resources/master.cf.d:/etc/postfix/master.cf.d:ro \
       $IMAGE sh -c 'postconf -M | grep -Fx \
-        "verify     unix  -       -       n       -       1       verify"'
+        "verify     unix  -       -       y       -       1       verify"'
   [ "$status" -eq 0 ]
 }
 
@@ -95,7 +95,7 @@
   run docker run --rm \
     -v $(pwd)/test/resources/master.cf.d:/etc/postfix/master.cf.d:ro \
       $IMAGE sh -c 'postconf -M | grep -Fx \
-        "pickup     fifo  n       -       y       60      1       pickup -o content_filter= -o receive_override_options=no_header_body_checks"'
+        "pickup     fifo  n       -       n       60      1       pickup -o content_filter= -o receive_override_options=no_header_body_checks"'
   [ "$status" -eq 0 ]
 
   # pickup/unix service is removed
@@ -106,11 +106,11 @@
 }
 
 @test "master.cf drop-in: lmtp/unix service is changed correctly" {
-  # lmtp/unix service is unchrooted
+  # lmtp/unix service is chrooted
   run docker run --rm \
     -v $(pwd)/test/resources/master.cf.d:/etc/postfix/master.cf.d:ro \
       $IMAGE sh -c 'postconf -M | grep -Fx \
-        "lmtp       unix  -       -       n       -       -       lmtp"'
+        "lmtp       unix  -       -       y       -       -       lmtp"'
   [ "$status" -eq 0 ]
 
   # lmtp/unix service is defined only once
@@ -121,12 +121,11 @@
 }
 
 
-@test "chroot: used by default for all postfix services that support it" {
+@test "chroot: nothing is chrooted by default" {
   run docker run --rm --entrypoint sh $IMAGE -c \
-    "postconf -M | grep -vE '^(proxymap|proxywrite|local|virtual)' \
-                 | awk '{ print \$5 }' \
+    "postconf -M | awk '{ print \$5 }' \
                  | tr -d '\n' \
-                 | grep -xE '^y+$'"
+                 | grep -xE '^n+$'"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
This PR reverts using `chroot` for Postfix services as was proposed in #7 and implemented in #8,
~~and leaves using `chroot` only for small number of Postfix services that do not talk to outside world or shared resources (except `syslog`)~~ (nope, as they all require configuration from `/etc/postfix`).


## Why?

Using `chroot` jails is a [technique to isolate process from the rest of the system](https://unix.stackexchange.com/a/109). This technique provides [a significant barrier against intrusion (but the barrier is not impenetrable)](http://www.postfix.org/BASIC_CONFIGURATION_README.html#chroot_setup) which is quite desirable for "traditional" system installations (multiple users, multiple background processes of different software in single OS user space).

However, Docker changes a way to think about it. Docker already provides an isolation from underlying OS, and in terms of Postfix `chroot`ing "the rest of the system" is everything inside container.  This Postfix Docker image is intended to run only Postfix inside container, so, technically,
there is no other stuff inside container to isolate Postfix from, as everything we mount in is required by Postfix itself.

Also, using `chroot` inside Docker container results in increased maintain expenses: we need to duplicate shared libs, configurations, and some binaries inside `chroot` directory as some services hardly depend on them (to resolve DNS, to use TLS, to relate service name with its port, etc.). This is not a big deal unless volume mounting comes in, which leads to a significant amount of job to be done (and done correctly) on container start. Such complicated job slows down container start and increases potential bugs to appear.

To sum up:  
Keeping container simple and predictable is much more preferable in this situation than unnecessarily increased isolation level (as there is nothing to isolate from).